### PR TITLE
Fixed CERN's Root link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This program is designed to run in a Unix-based system and has been tested on Ub
 ## Dependencies
 
 Required:
-* CERN's ROOT, which has its own installation instructions here: [https://root.cern/install/](https://root.cern.install/)
+* CERN's ROOT, which has its own installation instructions here: [https://root.cern/install/](https://root.cern/install/)
 * gcc, which can be installed via the command line (ex: `sudo apt-get install gcc`).
 
 Optional:


### PR DESCRIPTION
The main CERN's Root link needed some quick fix by changing its _URL_ (slash instead of dot).