### PR TITLE
Feature/root citation fix

### DIFF
--- a/paper/references.bib
+++ b/paper/references.bib
@@ -21,7 +21,7 @@
     url = {https://www.nndc.bnl.gov/nudat2/}
 }
 
-@article{ROOT,
+@article{ROOT_paperonly,
     title = {ROOT - An Object Oriented Data Analysis Framework},
     author = {Rene Brun and Fons Rademakers},
     journal = {Nucl. Inst. & Meth. in Phys. Res. A},
@@ -30,6 +30,16 @@
     year = {1997},
     note = "See also: \url{https://root.cern/}",
     url = {https://root.cern/}
+}
+
+@inproceedings{ROOT,
+    title = {ROOT - An Object Oriented Data Analysis Framework},
+    author = {Rene Brun and Fons Rademakers},
+    maintitle = {Proceedings AIHENP'96 Workshop},
+    booktitle = {Nucl. Inst. & Meth. in Phys. Res. A 389 (1997) 81-86.},
+    year = {1996},
+    month = {Sep.},
+    note = {See also "ROOT" [software], Release v6.22/00, 02/07/2020, (No DOI available for this version.)}
 }
 
 @article{lindhard,

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -21,7 +21,7 @@
     url = {https://www.nndc.bnl.gov/nudat2/}
 }
 
-@article{ROOT_paperonly,
+article{ROOT_paperonly,
     title = {ROOT - An Object Oriented Data Analysis Framework},
     author = {Rene Brun and Fons Rademakers},
     journal = {Nucl. Inst. & Meth. in Phys. Res. A},
@@ -39,8 +39,10 @@
     booktitle = {Nucl. Inst. & Meth. in Phys. Res. A 389 (1997) 81-86.},
     year = {1996},
     month = {Sep.},
-    url = {See also "ROOT" [software], Release v6.22/00, 02/07/2020, (No DOI available for this version.)}
+    note = {See also "ROOT" [software], Release v6.22/00, 02/07/2020, (No DOI available for this version.)},
+    url = {Nucl. Inst. & Meth. in Phys. Res. A 389 (1997) 81-86. See also "ROOT" [software], Release v6.22/00, 02/07/2020, (No DOI available for this version.)}
 }
+
 
 @article{lindhard,
     title = {Integral Equations Governing Radiation Effects},

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -39,7 +39,7 @@
     booktitle = {Nucl. Inst. & Meth. in Phys. Res. A 389 (1997) 81-86.},
     year = {1996},
     month = {Sep.},
-    note = {See also "ROOT" [software], Release v6.22/00, 02/07/2020, (No DOI available for this version.)}
+    url = {See also "ROOT" [software], Release v6.22/00, 02/07/2020, (No DOI available for this version.)}
 }
 
 @article{lindhard,


### PR DESCRIPTION
Resolve #4 with a workaround that uses the URL field to provide a note on the citation.

I tried to find another way to do this but could not. Because of the way compiling is done, I don't believe it's possible for me to install an alternative citation style or set a custom one as I would with plain LaTeX, which is needed to use the `note` or `booktitle` fields. This has the side-effect of not allowing formatting and turning the text blue, but it does get all of the text in there.

It was also not possible to provide a DOI link to the ROOT version that we are testing on because no Zenodo link exists for version 6.22/XX. @villaa , if you are running the code locally on an older version that is listed on [ROOT's provided Zenodo link](https://zenodo.org/search?page=1&size=20&q=conceptrecid:848818&all_versions&sort=-version), we could cite that version instead to get a DOI. (Or we could grab another v6 DOI and make a note about it? I am hesitant to link to a version we are not currently using in the citation, even if it should be compatible.)