### PR TITLE
Hotfix/1.2.4: Fixing the verbosity bug introduced--no output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ You can find more detailed documentation of *nrCascadeSim* [here](https://nrcasc
 
 If you decide to use this code, or if you want to add a reference to it, please cite the latest archived version,
 
-> Villano, A.N., Harris, K., Brown, S. , 2021, nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.3] [[DOI:10.5281/zenodo.5579857]](https://zenodo.org/record/5579857).
+> Villano, A.N., Harris, K., Brown, S. , 2021, nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.4] [[DOI:10.5281/zenodo.5579857]](https://zenodo.org/record/5579857).
 
 ```
 @software{nrcascadesim,
   author = {Villano, A.N. and Harris, K. and Brown S.},
-  title = {{nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.3]}},
+  title = {{nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.4]}},
   year         = {2021},
   publisher    = {Zenodo},
-  version      = {v1.2.3},
+  version      = {v1.2.4},
   doi          = {DOI:10.5281/zenodo.5579857},
   url          = {https://doi.org/10.5281/zenodo.5579857},
   howpublished={The code can be found under \url{https://github.com/villano-lab}.}
@@ -36,6 +36,7 @@ If you decide to use this code, or if you want to add a reference to it, please 
 
 ## VERSION HISTORY
 
+- 15.12.2021: Release of [version 1.2.4](https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.2.4)
 - 19.11.2021: Release of [version 1.2.3](https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.2.3)
 - 13.11.2021: Release of [version 1.2.0](https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.2.0)
 - 06.11.2021: Release of [version 1.1.3](https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.1.3)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,8 @@
-## Next Release (v1.2.3)
+## Next Release (v1.2.4)
+
+## Release (v1.2.4) Date 21.12.15
+
+* PR #51 Hotfix to remove the bug introduced by verbosity (solves issue #12)
 
 ## Release (v1.2.3) Date 21.11.19
 
@@ -20,7 +24,7 @@
 
 ## Release (v1.1.3) Date 21.11.06
 
-* PR #16 to lower default verbosity of realizeCascades (solves issue #12)
+* PR #16 to lower default verbosity of realizeCascades (solves issue #12; bug introduced see v1.2.4)
 * PR #20 adds more clarity to README documentation at top level (solves issue #8)
 
 ## Release (v1.1.1) Date 21.10.23

--- a/bin/realizeCascades.cpp
+++ b/bin/realizeCascades.cpp
@@ -134,7 +134,11 @@ int main(int argc, char** argv) {
           break;
 
       case 'V':
-        printf("Version: %s\n", __GIT_VERSION);
+        printf("realizeCascades (nrCascadeSim) %s\n", __GIT_VERSION);
+        printf("Copyright (c) 2020 Anthony Villano, Kitty Harris, Staci Brown \n");
+        printf("License MIT:  <https://opensource.org/licenses/MIT> \n");
+        printf("This is free software: you are free to change and redistribute it. \n");
+        printf("There is NO WARRANTY, to the extent permitted by law. \n");
         return 0;
         break;
 

--- a/bin/realizeCascades.cpp
+++ b/bin/realizeCascades.cpp
@@ -237,25 +237,24 @@ int main(int argc, char** argv) {
       //calculate the first cascade
       for(int k=0;k<numc;k++){
 	      int nrealize = num*cascadeFile[k].frac;
+              cri *cascade_data;
+              cascade_data = Cascade(nrealize,cascadeFile[k].cid,cascadeFile[k].Sn,cascadeFile[k].n,cascadeFile[k].Elev,cascadeFile[k].taus,cascadeFile[k].A,mtrand);
+              bool didsave = addToNRTTree(t,nrealize,cascade_data,cascadeFile[k]); 
+
         if(!logfile.empty()){  
           logging << "Realizing " << nrealize << " events of cascade ID " << cascadeFile[k].cid << endl;
-                cri *cascade_data;
-                cascade_data = Cascade(nrealize,cascadeFile[k].cid,cascadeFile[k].Sn,cascadeFile[k].n,cascadeFile[k].Elev,cascadeFile[k].taus,cascadeFile[k].A,mtrand);
-                logging << "Cascade realization " << k << " success: " << addToNRTTree(t,nrealize,cascade_data,cascadeFile[k]) << endl; 
+                logging << "Cascade realization " << k << " success: " << didsave << endl; 
           
-                freecriarray(nrealize,cascade_data);
               //************************************************************************************
         }
 
         if(verbosity >= 2){  
           cout << "Realizing " << nrealize << " events of cascade ID " << cascadeFile[k].cid << endl;
-                cri *cascade_data;
-                cascade_data = Cascade(nrealize,cascadeFile[k].cid,cascadeFile[k].Sn,cascadeFile[k].n,cascadeFile[k].Elev,cascadeFile[k].taus,cascadeFile[k].A,mtrand);
-                cout << "Cascade realization " << k << " success: " << addToNRTTree(t,nrealize,cascade_data,cascadeFile[k]) << endl; 
+                cout << "Cascade realization " << k << " success: " << didsave << endl; 
           
-                freecriarray(nrealize,cascade_data);
               //************************************************************************************
         }
+        freecriarray(nrealize,cascade_data);
       }
       freecliarray(numc,cascadeFile);
     }

--- a/bin/realizeCascades.cpp
+++ b/bin/realizeCascades.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <time.h>
 #include <stdint.h>
+#include <unistd.h>
 #include <iostream>
 #include <iomanip>
 #include <fstream>
@@ -167,11 +168,16 @@ int main(int argc, char** argv) {
   }
   std::vector<std::string> filenames;
   for(int i = optind; i < argc; i++){
-    if(verbosity>=1){
-      //print the filenames on a line
-      printf("%s\n",argv[i]);
+    if( access( argv[i], F_OK ) == 0 ) {
+      // file exists
+      if(verbosity>=1){
+        //print the filenames on a line
+        printf("%s\n",argv[i]);
+      }
+      filenames.push_back(argv[i]);
+    } else {
+      // file doesn't exist
     }
-    filenames.push_back(argv[i]);
   }
 
   //***********End get input*********************//

--- a/bin/realizeCascades.cpp
+++ b/bin/realizeCascades.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
       case 'V':
         printf("realizeCascades (nrCascadeSim) %s\n", __GIT_VERSION);
         printf("Copyright (c) 2020 Anthony Villano, Kitty Harris, Staci Brown \n");
-        printf("License MIT:  <https://opensource.org/licenses/MIT> \n");
+        printf("License The Expat license  <https://spdx.org/licenses/MIT.html> \n");
         printf("This is free software: you are free to change and redistribute it. \n");
         printf("There is NO WARRANTY, to the extent permitted by law. \n");
         return 0;

--- a/bin/realizeCascades.cpp
+++ b/bin/realizeCascades.cpp
@@ -58,6 +58,9 @@ void print_usage (FILE* stream, int exit_code)
            "  -V, --version                      print version and exit\n"
            "  -l, --log           <filename>     Log additional output to the specified file. If this option is not used, no logging will occur.\n");
 
+        printf("Report bugs to: villaa-at-gmail-dot-com \n");
+        printf("realizeCascades (nrCascadeSim) home page: <https://github.com/villano-lab/nrCascadeSim> \n");
+        printf("General help nrCascadeSim Software: <https://nrcascadesim.readthedocs.io/en/latest/> \n");
   exit (exit_code);
 }
 
@@ -143,7 +146,7 @@ int main(int argc, char** argv) {
         break;
 
       case 'h':
-        print_usage(stderr,0);
+        print_usage(stdout,0);
         return 0;
         break;
 

--- a/docs/source/01_Getting_Started.rst
+++ b/docs/source/01_Getting_Started.rst
@@ -73,6 +73,12 @@ To clean the installation use::
 
 	make clean
 
+or::
+
+	sudo make clean
+
+if after a `sudo make install`.
+
 
 ---------------------------------------
 Using *nrCascadeSim* command-line tools

--- a/docs/source/06_Citations.rst
+++ b/docs/source/06_Citations.rst
@@ -8,7 +8,7 @@ How to cite
 
 If you decide to use this code, or if you want to add a reference to it, please cite the latest archived version,
 
-    Villano, A.N., Harris, K., Brown, S., 2021, nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.3] [DOI:10.5281/zenodo.5579857]
+    Villano, A.N., Harris, K., Brown, S., 2021, nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.4] [DOI:10.5281/zenodo.5579857]
 
 .. raw:: html
 
@@ -19,10 +19,10 @@ If you decide to use this code, or if you want to add a reference to it, please 
 
     @software{nrcascadesim,
     author = {Villano, A.N. and Harris, K. and Brown S.},
-    title = {{nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.3]}},
+    title = {{nrCascadeSim - A tool for generating nuclear recoil spectra resulting from neutron capture [Code, v1.2.4]}},
     year         = {2021},
     publisher    = {Zenodo},
-    version      = {v1.2.3},
+    version      = {v1.2.4},
     doi          = {DOI:10.5281/zenodo.5579857},
     url          = {https://doi.org/10.5281/zenodo.5579857},
     howpublished={The code can be found under \url{https://github.com/villano-lab}.}

--- a/docs/source/07_Release_History.rst
+++ b/docs/source/07_Release_History.rst
@@ -2,6 +2,7 @@
 Release history
 ===============
 
+* 15.12.2021: Release of `v1.2.4 <https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.2.4>`_
 * 19.11.2021: Release of `v1.2.3 <https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.2.3>`_
 * 13.11.2021: Release of `v1.2.0 <https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.2.0>`_
 * 06.11.2021: Release of `v1.1.3 <https://github.com/villano-lab/nrCascadeSim/releases/tag/v1.1.3>`_

--- a/tests/test_realizeCascades
+++ b/tests/test_realizeCascades
@@ -6,4 +6,4 @@
 realizeCascades -n 100000 -o "output.root?reproducible=fixedname" -d 1 ../levelfiles/Si28_ngam_all_cascades_rfmt_sorted.txt 
 #> /dev/null
 md5sum output.root
-md5sum output.root | awk '{if ($1=="245881c2be8eb363799da1d79ac0478d"){system("rm output.root"); print"Checksum passed!"} else {system("rm output.root"); exit 1}}'
+md5sum output.root | awk '{if ($1=="2029e8b402b89d3a05d745e48f546370"){system("rm output.root"); print"Checksum passed!"} else {system("rm output.root"); exit 1}}'


### PR DESCRIPTION
When adding verbosity flags for issue #12 we introduced a bug where `realizeCascades` would not produce ROOT output unless the verbosity was set to at least level 2. 