### PR TITLE
Test for empty files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - sudo make install
 
   # give self permission to run script
-  - sudo chmod 777 test/test_realizeCascades.sh
+  - sudo chmod 777 tests/test_realizeCascades.sh
 
 script:
 - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 
 script:
 - cd tests
-- ./test_realizeCascades
+- ./test_realizeCascades.sh
 - cd ../example-usecase
 - travis_wait 50 py.test
 - source activate piptest

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ install:
   - make
   - sudo make install
 
+  # give self permission to run script
+  - sudo chmod 777 test/test_realizeCascades.sh
+
 script:
 - cd tests
 - ./test_realizeCascades.sh

--- a/tests/isempty.py
+++ b/tests/isempty.py
@@ -1,4 +1,4 @@
 import uproot
 file = uproot.open('output.root') #Change this to change tested file.
-if len(file['cascades'].keys()) == 0:
-	raise ValueError('No keys found under `cascades` - file appears to be empty!')
+if len(file['cascade'].keys()) == 0:
+	raise ValueError('No keys found under `cascade` - file appears to be empty!')

--- a/tests/isempty.py
+++ b/tests/isempty.py
@@ -1,0 +1,4 @@
+import uproot
+file = uproot.open('output.root') #Change this to change tested file.
+if len(file['cascades'].keys()) == 0:
+	raise ValueError('No keys found under `cascades` - file appears to be empty!')

--- a/tests/test_realizeCascades.sh
+++ b/tests/test_realizeCascades.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #for some systems like OSX
 #alias md5sum='md5'
@@ -8,9 +8,4 @@ realizeCascades -n 100000 -o "output.root?reproducible=fixedname" -d 1 ../levelf
 md5sum output.root
 md5sum output.root | awk '{if ($1=="2029e8b402b89d3a05d745e48f546370"){system("rm output.root"); print"Checksum passed!"} else {system("rm output.root"); exit 1}}'
 # Check that file is uncorrupted and has data
-root  -b -l -q <<EOF
-TFile f("output.root")
-if f -> IsZombie():
-	exit(-1)
-fi
-EOF
+python ./isempty.py

--- a/tests/test_realizeCascades.sh
+++ b/tests/test_realizeCascades.sh
@@ -4,8 +4,8 @@
 #alias md5sum='md5'
 
 realizeCascades -n 100000 -o "output.root?reproducible=fixedname" -d 1 ../levelfiles/Si28_ngam_all_cascades_rfmt_sorted.txt 
-#> /dev/null
+# Check that file is uncorrupted and has data
+python3 ./isempty.py
+# Check md5sum
 md5sum output.root
 md5sum output.root | awk '{if ($1=="2029e8b402b89d3a05d745e48f546370"){system("rm output.root"); print"Checksum passed!"} else {system("rm output.root"); exit 1}}'
-# Check that file is uncorrupted and has data
-python ./isempty.py

--- a/tests/test_realizeCascades.sh
+++ b/tests/test_realizeCascades.sh
@@ -8,4 +8,4 @@ realizeCascades -n 100000 -o "output.root?reproducible=fixedname" -d 1 ../levelf
 python3 ./isempty.py
 # Check md5sum
 md5sum output.root
-md5sum output.root | awk '{if ($1=="2029e8b402b89d3a05d745e48f546370"){system("rm output.root"); print"Checksum passed!"} else {system("rm output.root"); exit 1}}'
+md5sum output.root | awk '{if ($1=="d7e9f904dbc4069667a9d05cad58754c"){system("rm output.root"); print"Checksum passed!"} else {system("rm output.root"); exit 1}}'


### PR DESCRIPTION
Resolve #50 by running a python script on the generated file to make sure that there are entries within the `cascade` key in the file. (I have checked with genuinely empty files to confirm that no sub-keys exist if no cascades are simulated.)