### PR TITLE
readthedocs fail on warning

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
-   fail_on_warning: false 
+   fail_on_warning: true 
 
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,7 @@
 ## Future Releases (v1.3.1) Date XX.XX.XX 
 
+* PR #62 added fail-on-warning flag for readthedocs (Issue #41)
+
 ## Release (v1.3.0) Date 21.12.27
 
 * PR #54 Move MersenneTwister to built-in C++ function. (Issue #27)


### PR DESCRIPTION
Trying this will solve issue #41 simply by putting the fail-on-warn flag on in `.readthedocs.yaml`
