### PR TITLE
add .gcda and .gcno files to be cleaned with CMake scrub target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,18 +127,6 @@ message("Linker Flags: ${CMAKE_EXE_LINKER_FLAGS}")
 
 #----------------------------------------------------------------------------
 #Main part
-## list of source files
-#set(libsrc source1.c source2.c)
-#
-## this is the "object library" target: compiles the sources only once
-#add_library(objlib OBJECT ${libsrc})
-#
-## shared libraries need PIC
-#set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
-#
-## shared and static libraries built from the same object files
-#add_library(MyLib_shared SHARED $<TARGET_OBJECTS:objlib>)
-#add_library(MyLib_static STATIC $<TARGET_OBJECTS:objlib>)
 
 set(caplibsrc ${srcDir}/isotope_info.cpp ${srcDir}/rootUtil.cpp ${srcDir}/edepmath.cpp  ${srcDir}/weisskopf.cpp ${srcDir}/lindhard.cpp ${srcDir}/cascadeProd.cpp)
 link_libraries(ROOT::Core ROOT::RIO ROOT::Tree)
@@ -169,4 +157,21 @@ add_custom_target(tests
 
 add_custom_target(uninstall
                 COMMAND xargs rm < install_manifest.txt 
+)
+
+#----------------------------------------------------------------------------
+#scrub target
+
+# Create OBJECT_DIR variable
+#set(OBJECT_DIR ${CMAKE_BINARY_DIR}/CMakeFiles/realizeCascades.dir/bin ${CMAKE_BINARY_DIR}/CMakeFiles/libncap_obj.dir/src)
+set(OBJECT_DIR ${CMAKE_BINARY_DIR}/CMakeFiles/realizeCascades.dir/bin)
+message("-- Object files will be output to: ${OBJECT_DIR}")
+
+# Create the gcov-clean target. This cleans the build as well as generated 
+# .gcda and .gcno files.
+add_custom_target(scrub
+COMMAND ${CMAKE_MAKE_PROGRAM} clean
+COMMAND rm -f ${OBJECT_DIR}/*.gcno
+COMMAND rm -f ${OBJECT_DIR}/*.gcda
+WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,14 +164,30 @@ add_custom_target(uninstall
 
 # Create OBJECT_DIR variable
 #set(OBJECT_DIR ${CMAKE_BINARY_DIR}/CMakeFiles/realizeCascades.dir/bin ${CMAKE_BINARY_DIR}/CMakeFiles/libncap_obj.dir/src)
-set(OBJECT_DIR ${CMAKE_BINARY_DIR}/CMakeFiles/realizeCascades.dir/bin)
+set(OBJECT_DIR ${CMAKE_BINARY_DIR}/CMakeFiles/realizeCascades.dir/bin/*.gcda
+${CMAKE_BINARY_DIR}/CMakeFiles/realizeCascades.dir/bin/*.gcno
+${CMAKE_BINARY_DIR}/CMakeFiles/regexPlayground.dir/bin/*.gcda
+${CMAKE_BINARY_DIR}/CMakeFiles/regexPlayground.dir/bin/*.gcno
+${CMAKE_BINARY_DIR}/CMakeFiles/fetchYieldModel.dir/tests/bin/*.gcda
+${CMAKE_BINARY_DIR}/CMakeFiles/fetchYieldModel.dir/tests/bin/*.gcno
+${CMAKE_BINARY_DIR}/CMakeFiles/printIsotopeInfo.dir/tests/bin/*.gcda
+${CMAKE_BINARY_DIR}/CMakeFiles/printIsotopeInfo.dir/tests/bin/*.gcno
+${CMAKE_BINARY_DIR}/CMakeFiles/readLevelfile.dir/tests/bin/*.gcda
+${CMAKE_BINARY_DIR}/CMakeFiles/readLevelfile.dir/tests/bin/*.gcno
+${CMAKE_BINARY_DIR}/CMakeFiles/realizeAndSave.dir/tests/bin/*.gcda
+${CMAKE_BINARY_DIR}/CMakeFiles/realizeAndSave.dir/tests/bin/*.gcno
+${CMAKE_BINARY_DIR}/CMakeFiles/libncap_obj.dir/src/*.gcda
+${CMAKE_BINARY_DIR}/CMakeFiles/libncap_obj.dir/src/*.gcno
+)
 message("-- Object files will be output to: ${OBJECT_DIR}")
 
 # Create the gcov-clean target. This cleans the build as well as generated 
 # .gcda and .gcno files.
 add_custom_target(scrub
 COMMAND ${CMAKE_MAKE_PROGRAM} clean
-COMMAND rm -f ${OBJECT_DIR}/*.gcno
-COMMAND rm -f ${OBJECT_DIR}/*.gcda
+#COMMAND rm -f ${OBJECT_DIR}/*.gcno
+#COMMAND rm -f ${OBJECT_DIR}/*.gcda
+COMMAND rm -f ${OBJECT_DIR}
+
 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 * PR #91 migrated to CMake (Issues #85, #64, #26)
 * PR #95 added proper coverage behavior to CMake (Issues #94, #93, #92)
+* PR #99 remove .gcda and .gcno files on `make scrub` (Issues #84)
 
 ## Releases (v1.3.2) Date 22.01.08 
 


### PR DESCRIPTION
Used [this example](https://jhbell.com/using-cmake-and-gcov) to explicitly remove the `.gcda` and `.gcno` code coverage files with the `make scrub` target. The `make scrub` begins with a make clean and then removes all the above files too.

**Does your pull request resolve or partially resolve an issue?** 
Yes 

**If Yes, which issue?** 
#84 

**Does your pull request implement code improvements?**
No.

**Does your pull request implement any breaking changes?**
No.

**If breaking changes are implemented, please describe:**

**Testing:**  
This pull request:
[ ] Alters the existing CI in some way.
[ ] Adds a new step to the CI.
[ x] Does not introduce any features that the CI could not already test.
[ ] Is not accompanied by necessary CI changes due to some limitation described below. (Please also describe how new features can be manually tested.)

